### PR TITLE
Don't limit codespell to lisp comments

### DIFF
--- a/flymake-codespell.el
+++ b/flymake-codespell.el
@@ -121,7 +121,7 @@ LOCUS, BEG, END, TYPE and TEXT are passed as is to
                     (cl-loop
                      while (re-search-forward
                             (rx bol
-                                (group (+ digit)) ": ;; " (+ nonl) "\n"
+                                (group (+ digit)) ": " (+ nonl) "\n"
                                 (+ space) (group (+ any)) " ==> " (group (+ any)))
                             nil t)
                      for typo = (match-string 2)


### PR DESCRIPTION
It seems like flymake-codespell only detects misspellings in lisp comments, due to the regexp matcher looking for `(group (+ digit)) ": ;; " (+ nonl)`. Is that an intentional choice?
How do you feel about opening it up to report all of the misspellings that `codespell` reports, like in this PR?